### PR TITLE
build(django): bump version to 5.2.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ click==8.1.8
 colorama==0.4.6
 cookiecutter==2.6.0
 cssbeautifier==1.15.4
-Django==5.2
+Django==5.2.2
 django-stubs==5.1.3
 django-stubs-ext==5.1.3
 djlint==1.36.4


### PR DESCRIPTION
## Description

This Django version update resolves 2 security issues:

1. CVE-2025-32873: Denial-of-service possibility in strip_tags()
[strip_tags()](https://docs.djangoproject.com/en/5.2/ref/utils/#django.utils.html.strip_tags) would be slow to evaluate certain inputs containing large sequences of incomplete HTML tags. This function is used to implement the [striptags](https://docs.djangoproject.com/en/5.2/ref/templates/builtins/#std-templatefilter-striptags) template filter, which was thus also vulnerable.
[strip_tags()](https://docs.djangoproject.com/en/5.2/ref/utils/#django.utils.html.strip_tags) now raises a [SuspiciousOperation](https://docs.djangoproject.com/en/5.2/ref/exceptions/#django.core.exceptions.SuspiciousOperation) exception if it encounters an unusually large number of unclosed opening tags
2. CVE-2025-48432: Potential log injection via unescaped request path
Internal HTTP response logging used request.path directly, allowing control characters (e.g. newlines or ANSI escape sequences) to be written unescaped into logs. This could enable log injection or forgery, letting attackers manipulate log appearance or structure, especially in logs processed by external systems or viewed in terminals.
Although this does not directly impact Django’s security model, it poses risks when logs are consumed or interpreted by other tools. To fix this, the internal django.utils.log.log_response() function now escapes all positional formatting arguments using a safe encoding.

## Links

[Django 5.2.1 release notes](https://docs.djangoproject.com/en/5.2/releases/5.2.1/)
[Django 5.2.2 release notes](https://docs.djangoproject.com/en/5.2/releases/5.2.2/)